### PR TITLE
feat: increase timeout to 10 seconds

### DIFF
--- a/src/gitProviders/gitlab.js
+++ b/src/gitProviders/gitlab.js
@@ -28,7 +28,7 @@ export class Gitlab {
     authenticate() {
         return axios.create({
             baseURL: `${this.config.baseUrl}`,
-            timeout: 1000,
+            timeout: 10000,
             headers: { Authorization: `Bearer ${this.config.token}` },
         });
     }


### PR DESCRIPTION
If you have large collection, there is a timeout issue, 1s is not enough to pull from repository.
I think it needs more seconds for timeout