### PR TITLE
fix: fall back to config.json as config file name if none is entered && fix: wrong branch stored 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "insomnia-plugin-universal-git",
-    "version": "1.3.1",
+    "version": "1.3.2",
     "description": "Plugin to sync your insomnia collections and environments with GitLab or Github",
     "main": "dist/index.js",
     "files": [

--- a/src/gitProviders/gitlab.ts
+++ b/src/gitProviders/gitlab.ts
@@ -17,11 +17,11 @@ export class Gitlab {
   private async initRemoteConfigFile() {
     try {
       await this.authenticate().post(
-        `${this.config.baseUrl}/api/v4/projects/${this.config.projectId}/repository/files/${this.config.configFileName}`,
+        `${this.config.baseUrl}/api/v4/projects/${this.config.projectId}/repository/files/${this.config.configFileName || 'config.json'}`,
         {
           "branch": this.config.branch,
           "content": "{}",
-          "commit_message": `Init new config file ${this.config.configFileName}`
+          "commit_message": `Init new config file ${this.config.configFileName || 'config.json'}`
         }
       );
     } catch(e) {
@@ -62,7 +62,7 @@ export class Gitlab {
   async pullWorkspace() {
     try {
       const response = await this.authenticate().get(
-        `${this.config.baseUrl}/api/v4/projects/${this.config.projectId}/repository/files/${this.config.configFileName}/raw?ref=${this.config.branch}`
+        `${this.config.baseUrl}/api/v4/projects/${this.config.projectId}/repository/files/${this.config.configFileName || 'config.json'}/raw?ref=${this.config.branch}`
       );
       return(response.data);
     } catch (e) {
@@ -81,7 +81,7 @@ export class Gitlab {
         "actions": [
           {
             "action": "update",
-            "file_path": this.config.configFileName,
+            "file_path": this.config.configFileName || 'config.json',
             "content": content
           }
         ]
@@ -98,7 +98,7 @@ export class Gitlab {
             "actions": [
               {
                 "action": "update",
-                "file_path": this.config.configFileName,
+                "file_path": this.config.configFileName || 'config.json',
                 "content": content
               }
             ]

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,6 +8,7 @@ async function loadConfig(context): Promise<UserConfig | null> {
     try {
         return JSON.parse(storedConfig);
     } catch(e) {
+        console.error("Loading config failed: ", e);
         return null;
     }
 }
@@ -68,7 +69,7 @@ class GitlabConfigForm extends React.Component<any, any> {
         });
 
         this.setState({
-            'branch': this.state.branch ? this.state.branch : branches[0],
+            'branch': this.state.branch && this.state.branch in branches ? this.state.branch : branches[0],
             'branchOptions': branchOptions
         });
     }


### PR DESCRIPTION
fixes #12 

Should fix all problems described in #12. 

fix: fall back to config.json as config file name if none is entered
fix: Fall back to default branch if last saved ref doesn't exist on remote anymore